### PR TITLE
Update FetchAccessTokenRequestExecutor.java

### DIFF
--- a/src/main/java/cd/go/authorization/github/executors/FetchAccessTokenRequestExecutor.java
+++ b/src/main/java/cd/go/authorization/github/executors/FetchAccessTokenRequestExecutor.java
@@ -83,8 +83,8 @@ public class FetchAccessTokenRequestExecutor implements RequestExecutor {
                 .addPathSegment("login")
                 .addPathSegment("oauth")
                 .addPathSegment("access_token")
-                .addQueryParameter("client_id", gitHubConfiguration.clientId())
-                .addQueryParameter("client_secret", gitHubConfiguration.clientSecret())
+                .addHeader("client_id", gitHubConfiguration.clientId())
+                .addHeader("client_secret", gitHubConfiguration.clientSecret())
                 .addQueryParameter("code", request.requestParameters().get("code"))
                 .build().toString();
     }


### PR DESCRIPTION
`client_id` and `client_secret` changed from query params to header, as specified by GitHub auth patch:
-> https://developer.github.com/changes/2020-02-14-deprecating-oauth-app-endpoint/
-> https://developer.github.com/changes/2019-11-05-deprecated-passwords-and-authorizations-api/